### PR TITLE
cmd,pkg: fix nil dereference when running kubeless install

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,11 @@ func newControllerConfig(masterHost, ns string) controller.Config {
 		if err != nil {
 			fmt.Errorf("Can not get kubernetes config: %s", err)
 		}
-		masterHost = k8sConfig.Host
+		if k8sConfig == nil {
+			fmt.Errorf("Got nil k8sConfig, please check if k8s cluster is available.")
+		} else {
+			masterHost = k8sConfig.Host
+		}
 	}
 	cfg := controller.Config{
 		Namespace:  ns,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -163,6 +163,9 @@ func (c *Controller) Run() error {
 }
 
 func (c *Controller) initResource() error {
+	if c.Config.MasterHost == "" {
+		return fmt.Errorf("MasterHost is empty. Please check if k8s cluster is available.")
+	}
 	err := c.createTPR()
 	if err != nil {
 		if !utils.IsKubernetesResourceAlreadyExistError(err) {


### PR DESCRIPTION
`kubeless install` command can panic when no kubernetes cluster is available, like the following:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x45eb0d]

goroutine 1 [running]:
panic(0x1adc6e0, 0xc420010250)
        /usr/local/golang/src/runtime/panic.go:500 +0x1a1
github.com/skippbox/kubeless/cmd.newControllerConfig(0x0, 0x0, 0x1cce16e, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/skippbox/kubeless/cmd/root.go:75 +0x1bd
github.com/skippbox/kubeless/cmd.glob..func5(0x2b87a00, 0x2bfa458, 0x0, 0x0)
        /go/src/github.com/skippbox/kubeless/cmd/install.go:41 +0x207
github.com/skippbox/kubeless/vendor/github.com/spf13/cobra.(*Command).execute(0x2b87a00, 0x2bfa458, 0x0, 0x0, 0x2b87a00, 0x2bfa458)
        /go/src/github.com/skippbox/kubeless/vendor/github.com/spf13/cobra/command.go:636 +0x443
github.com/skippbox/kubeless/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x2b88280, 0xc42007e058, 0x0, 0xc42065ff08)
        /go/src/github.com/skippbox/kubeless/vendor/github.com/spf13/cobra/command.go:722 +0x367
github.com/skippbox/kubeless/vendor/github.com/spf13/cobra.(*Command).Execute(0x2b88280, 0x0, 0x0)
        /go/src/github.com/skippbox/kubeless/vendor/github.com/spf13/cobra/command.go:681 +0x2b
github.com/skippbox/kubeless/cmd.Execute()
        /go/src/github.com/skippbox/kubeless/cmd/root.go:48 +0x31
main.main()
        /go/src/github.com/skippbox/kubeless/main.go:22 +0x14
```

Fix it by setting `masterHost` only when `k8sConfig` is not nil. Otherwise `masterHost` needs to be an empty string, which will cause later `Controller.createTPR()` to be skipped in `Controller.initResource()`.