### PR TITLE
add minio example

### DIFF
--- a/examples/minio/README.md
+++ b/examples/minio/README.md
@@ -1,0 +1,100 @@
+# Minio Example
+
+This example uses the Minio S3 clone to show case a kubeless pubsub function.
+Minio is configured to send notifications to Kafka, a function consumes those events and performs actions.
+
+The Minio access keys are stored as a Kubernetes secret
+
+## Deploy Minio via Helm
+
+If you have clone the kubeless repo:
+
+```
+cd examples
+cd minio
+helm install ./minio
+```
+
+This will use the default values in `./minio/values.yaml`
+
+Check the logs of the Minio pod for configuration info.
+
+## Minio configuration
+
+You will need the Minio [client](https://github.com/minio/mc) `mc`:
+
+```
+brew install minio-mc
+```
+
+The following are Minio specific, it assumes your are using minikube on `192.168.99.100`
+
+```
+mc config host add localminio http://192.168.99.100:32751 foobar foobarfoo
+```
+
+Login to the Minio UI and create a `foobar` bucket:
+
+```
+minikube services <helm_release_name_for_minio>
+```
+
+Turn on events for a `foobar` bucket:
+
+```
+mc events add localminio/foobar arn:minio:sqs:us-east-1:1:kafka
+```
+
+Check bucket
+
+```
+mc ls localminio/<bucket_name>
+```
+
+## Use Kubeless to echo Minio events
+
+Write a echo function
+
+```
+def handler(context):
+    return context
+```
+
+Create a topic (by default the Helm chart used the `s3` topic):
+
+```
+kubeless topic create s3
+```
+
+Create the function with kubeless:
+
+```
+kubeless function create pubsub --trigger-topic s3 --runtime python27 --handler pubsub.handler --from-file python/pubsub.py
+```
+
+Watch the logs of the pods for Minio events:
+
+```
+$ kubectl logs -f pubsub-2287267129-07czk
+{u'level': u'info', u'EventType': u's3:ObjectRemoved:Delete', u'Records': [{u'eventVersion': u'2.0', u'eventTime': u'2017-03-17T10:52:30Z', u'requestParameters': {u'sourceIPAddress': u'172.17.0.1:57970'}, u's3': {u'configurationId': u'Config', u'object': {u'sequencer': u'14ACA5DE4CE37B2F', u'key': u'foobar.py'}, u'bucket': {u'arn': u'arn:aws:s3:::foobar', u'name': u'foobar', u'ownerIdentity': {u'principalId': u'foobar'}}, u's3SchemaVersion': u'1.0'}, u'responseElements': {u'x-amz-request-id': u'14ACA5DE4CE37B2F', u'x-minio-origin-endpoint': u'http://172.17.0.9:9000'}, u'awsRegion': u'us-east-1', u'eventName': u's3:ObjectRemoved:Delete', u'userIdentity': {u'principalId': u'foobar'}, u'eventSource': u'aws:s3'}], u'Key': u'foobar/foobar.py', u'time': u'2017-03-17T10:52:30Z', u'msg': u''}
+<type 'dict'>
+{u'level': u'info', u'EventType': u's3:ObjectCreated:Put', u'Records': [{u'eventVersion': u'2.0', u'eventTime': u'2017-03-17T10:52:42Z', u'requestParameters': {u'sourceIPAddress': u'172.17.0.1:57970'}, u's3': {u'configurationId': u'Config', u'object': {u'eTag': u'd8e9cdac05040c688fe2ea331bdc97fd', u'sequencer': u'14ACA5E103E5C379', u'key': u'cli.py', u'size': 177}, u'bucket': {u'arn': u'arn:aws:s3:::foobar', u'name': u'foobar', u'ownerIdentity': {u'principalId': u'foobar'}}, u's3SchemaVersion': u'1.0'}, u'responseElements': {u'x-amz-request-id': u'14ACA5E103E5C379', u'x-minio-origin-endpoint': u'http://172.17.0.9:9000'}, u'awsRegion': u'us-east-1', u'eventName': u's3:ObjectCreated:Put', u'userIdentity': {u'principalId': u'foobar'}, u'eventSource': u'aws:s3'}], u'Key': u'foobar/cli.py', u'time': u'2017-03-17T10:52:42Z', u'msg': u''}
+<type 'dict'>
+```
+
+## Use Kubeless for managing files
+
+Your function will need access to Minio, create a secret with your access keys:
+
+```
+kubectl create secret generic minio --from-literal=access_key=foobar --from-literal=secret_key=foobarfoo
+```
+
+Create the function:
+
+```
+kubeless function create minio --trigger-topic s3 --runtime python27 --handler minio-test.ocr --from-file minio-test.py --dependencies requirements.txt
+```
+
+Create a `foobar` and a `ocr` bucket in Minio UI.
+Add an object in the `foobar` bucket and watch it being put in the `ocr` bucket with `.ocr` extension

--- a/examples/minio/minio-test.py
+++ b/examples/minio/minio-test.py
@@ -1,0 +1,49 @@
+import base64
+import tempfile
+
+#pip install kubernetes
+from kubernetes import client, config
+
+# pip install minio
+from minio import Minio
+from minio.error import ResponseError
+
+config.load_incluster_config()
+
+v1=client.CoreV1Api()
+
+for secrets in v1.list_secret_for_all_namespaces().items:
+    if secrets.metadata.name == 'minio':
+        access_key = base64.b64decode(secrets.data['access_key'])
+        secret_key = base64.b64decode(secrets.data['secret_key'])
+
+# Replace the DNS below with the minio service name (helm release name -svc)
+client = Minio('mangy-tapir-minio-svc:9000',
+                  access_key=access_key,
+                  secret_key=secret_key,
+                  secure=False)
+
+def ocr(context):
+    if context['EventType'] == "s3:ObjectCreated:Put" and context['Key'].split('/')[0] == 'foobar':
+
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        bucket = context['Key'].split('/')[0]
+        filename = context['Key'].split('/')[1]
+
+        try:
+            client.fget_object(bucket, filename, tf.name)
+        except ResponseError as err:
+            print err
+        
+
+        # puts the same file in a OCR bucket
+        ocr_name = filename + '.ocr'
+        try:
+            client.fput_object('ocr',ocr_name,tf.name)
+        except ResponseError as err:
+            print err
+
+    else:
+        print "Minio file deletion event"
+
+    return "OCR called"

--- a/examples/minio/minio/.helmignore
+++ b/examples/minio/minio/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/examples/minio/minio/Chart.yaml
+++ b/examples/minio/minio/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Distributed object storage server built for cloud applications and devops.
+name: minio
+version: 0.1.0
+keywords:
+- storage
+- object-storage
+- S3
+home: https://minio.io
+icon: https://www.minio.io/logo/img/logo-dark.svg
+sources:
+- https://github.com/minio/minio
+maintainers:
+- name: Acaleph
+  email: hello@acale.ph
+- name: Minio
+  email: hello@minio.io

--- a/examples/minio/minio/README.md
+++ b/examples/minio/minio/README.md
@@ -1,0 +1,169 @@
+Minio
+=====
+
+[Minio](https://minio.io) is a lightweight, AWS S3 compatible object storage server. It is best suited for storing unstructured data such as photos, videos, log files, backups, VM and container images. Size of an object can range from a few KBs to a maximum of 5TB. Minio server is light enough to be bundled with the application stack, similar to NodeJS, Redis and MySQL.
+
+Minio supports [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide). In distributed mode, you can pool multiple drives (even on different machines) into a single object storage server.
+
+Introduction
+------------
+
+This chart bootstraps Minio deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
+-   Kubernetes 1.5+ with Beta APIs enabled to run Minio in [distributed mode](#distributed-minio).
+-	PV provisioner support in the underlying infrastructure.
+
+Installing the Chart
+--------------------
+
+Install this chart using:
+
+```bash
+$ helm install stable/minio
+```
+
+The command deploys Minio on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Release name
+
+An instance of a chart running in a Kubernetes cluster is called a release. Each release is identified by a unique name within the cluster. Helm automatically assigns a unique release name after installing the chart. You can also set your preferred name by:
+
+```bash
+$ helm install --name my-release stable/minio
+```
+
+### Access and Secret keys
+
+By default a pre-generated access and secret key will be used. To override the default keys, pass the access and secret keys as arguments to helm install.
+
+```bash
+$ helm install --set accessKey=myaccesskey,secretKey=mysecretkey \
+    stable/minio
+```
+### Updating Minio configuration via Helm
+
+[ConfigMap](https://kubernetes.io/docs/user-guide/configmap/) allows injecting containers with configuration data even while a Helm release is deployed.
+
+To update your Minio server configuration while it is deployed in a release, you need to
+
+1. Check all the configurable values in the Minio chart using `helm inspect values stable/minio`.
+2. Override the `minio_server_config` settings in a YAML formatted file, and then pass that file like this `helm upgrade -f config.yaml stable/minio`.
+3. Restart the Minio server(s) for the changes to take effect.
+
+You can also check the history of upgrades to a release using `helm history my-release`. Replace `my-release` with the actual release name.
+
+Uninstalling the Chart
+----------------------
+
+Assuming your release is named as `my-release`, delete it using the command:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Configuration
+-------------
+
+The following tables lists the configurable parameters of the Minio chart and their default values.
+
+| Parameter                  | Description                         | Default                                                 |
+|----------------------------|-------------------------------------|---------------------------------------------------------|
+| `image`                    | Minio image name                    | `minio/minio`                                           |
+| `imageTag`                 | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2017-02-16T01-47-30Z`|
+| `imagePullPolicy`          | Image pull policy                   | `Always`                                                |
+| `mode`                     | Minio server mode (`standalone`, `shared` or `distributed`)| `standalone`                     |
+| `replicas`                 | Number of nodes (applicable only for Minio distributed mode). Should be 4 <= x <= 16 | `4`    |
+| `accessKey`                | Default access key                  | `AKIAIOSFODNN7EXAMPLE`                                  |
+| `secretKey`                | Default secret key                  | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`              |
+| `configPath`               | Default config file location        | `~/.minio`                                              |
+| `mountPath`                | Default mount location for persistent drive| `/export`                                        |
+| `serviceType`              | Kubernetes service type             | `LoadBalancer`                                          |
+| `servicePort`              | Kubernetes port where service is exposed| `9000`                                              |
+| `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
+| `persistence.size`         | Size of persistent volume claim     | `10Gi`                                                  |
+| `persistence.storageClass` | Type of persistent volume claim     | `generic`                                               |
+| `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
+| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                            |
+
+Some of the parameters above map to the env variables defined in the [Minio DockerHub image](https://hub.docker.com/r/minio/minio/).
+
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set persistence.size=100Gi \
+    stable/minio
+```
+
+The above command deploys Minio server with a 100Gi backing persistent volume.
+
+Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/minio
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+Distributed Minio
+-----------
+
+This chart provisions a Minio server in standalone mode, by default. To provision Minio server in [distributed mode](https://docs.minio.io/docs/distributed-minio-quickstart-guide), set the `mode` field to `distributed`,
+
+```bash
+$ helm install --set mode=distributed stable/minio
+```
+
+This provisions Minio server in distributed mode with 4 nodes. To change the number of nodes in your distributed Minio server, set the `replicas` field,
+
+```bash
+$ helm install --set mode=distributed,replicas=8 stable/minio
+```
+
+This provisions Minio server in distributed mode with 8 nodes. Note that the `replicas` value should be an integer between 4 and 16 (inclusive).
+
+### StatefulSet [limitations](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations) applicable to distributed Minio
+
+1. StatefulSets need persistent storage, so the `persistence.enabled` flag is ignored when `mode` is set to `distributed`.
+2. When uninstalling a distributed Minio release, you'll need to manually delete volumes associated with the StatefulSet.
+
+Shared Minio
+-----------
+
+### Prerequisites
+
+Minio shared mode deployment creates multiple Minio server instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy Minio shared mode you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
+outlines steps to create a NFS PV in Kubernetes cluster.
+
+### Provision Shared Minio instances
+
+To provision Minio servers in [shared mode](https://github.com/minio/minio/blob/master/docs/shared-backend/README.md), set the `mode` field to `shared`,
+
+```bash
+$ helm install --set mode=shared stable/minio
+```
+
+This provisions 4 Minio server nodes backed by single storage. To change the number of nodes in your shared Minio deployment, set the `replicas` field,
+
+```bash
+$ helm install --set mode=shared,replicas=8 stable/minio
+```
+
+This provisions Minio server in shared mode with 8 nodes.
+
+Persistence
+-----------
+
+This chart provisions a PersistentVolumeClaim and mounts corresponding persistent volume to default location `/export`. You'll need physical storage available in the Kubernetes cluster for this to work. If you'd rather use `emptyDir`, disable PersistentVolumeClaim by:
+
+```bash
+$ helm install --set persistence.enabled=false stable/minio
+```
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*

--- a/examples/minio/minio/templates/NOTES.txt
+++ b/examples/minio/minio/templates/NOTES.txt
@@ -1,0 +1,38 @@
+{{- if eq .Values.serviceType "ClusterIP" }}
+Minio can be accessed via port {{ .Values.servicePort }} on the following DNS name from within your cluster:
+{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Minio from localhost, run the below commands:
+
+  1. export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+
+  2. kubectl port-forward $POD_NAME 9000 --namespace {{ .Release.Namespace }}
+
+Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/
+
+You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "fullname" . }}-local http://localhost:9000 {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}
+{{- if eq .Values.serviceType "LoadBalancer" }}
+Minio can be accessed via port {{ .Values.servicePort }} on an external IP address. Get the service external IP address by:
+kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
+
+Note that the public IP may take a couple of minutes to be available.
+
+You can now access Minio server on http://<External-IP>:9000. Follow the below steps to connect to Minio server with mc client:
+
+  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
+
+  2. mc config host add {{ template "fullname" . }}-local http://<External-IP>:{{ .Values.servicePort }} {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+
+  3. mc ls {{ template "fullname" . }}-local
+
+Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
+{{- end }}

--- a/examples/minio/minio/templates/_helpers.tpl
+++ b/examples/minio/minio/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/minio/minio/templates/minio_deployment.yaml
+++ b/examples/minio/minio/templates/minio_deployment.yaml
@@ -1,0 +1,76 @@
+{{- if eq .Values.mode "standalone" "shared" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  {{- if eq .Values.mode "shared" }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      volumes:
+        - name: export
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: minio-server-config
+          configMap:
+            name: {{ template "fullname" . }}-config-cm
+        - name: minio-user
+          secret:
+            secretName: {{ template "fullname" . }}-user
+      containers:
+        - name: minio
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["minio"]
+          {{- if .Values.configPath }}
+          args: ["-C", "{{ .Values.configPath }}", "server", "{{ .Values.mountPath }}"]
+          {{- else }}
+          args: ["server", "{{ .Values.mountPath }}"]
+          {{- end }}
+          volumeMounts:
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+            - name: minio-server-config
+              mountPath: {{ default "/root/.minio/" .Values.configPath | quote }}
+          ports:
+            - name: service
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: secretkey
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/examples/minio/minio/templates/minio_distributed_configmap.yaml
+++ b/examples/minio/minio/templates/minio_distributed_configmap.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.mode "distributed" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-cm
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{ $nodeCount := .Values.replicas | int }}
+data:
+  start.sh: |
+     #!/bin/sh
+     {{- if .Values.configPath }}
+     minio -C {{ .Values.configPath }} server \
+     {{- else }}
+     minio server \
+     {{- end }}
+     {{- range $i := until $nodeCount }}
+     http://{{ template "fullname" $ }}-{{$i}}.{{ template "fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }} \
+{{- end }}
+{{- end }}

--- a/examples/minio/minio/templates/minio_pvc.yaml
+++ b/examples/minio/minio/templates/minio_pvc.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.mode "standalone" "shared" }}
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+{{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+{{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+{{- end }}
+spec:
+  accessModes:
+    {{- if eq .Values.mode "shared" }}
+    - ReadWriteMany
+    {{- else }}
+    - {{ .Values.persistence.accessMode | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}
+{{- end }}

--- a/examples/minio/minio/templates/minio_secret.yaml
+++ b/examples/minio/minio/templates/minio_secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-user
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  accesskey: {{ .Values.accessKey | b64enc }}
+  secretkey: {{ .Values.secretKey | b64enc }}

--- a/examples/minio/minio/templates/minio_statefulset.yaml
+++ b/examples/minio/minio/templates/minio_statefulset.yaml
@@ -1,0 +1,100 @@
+{{- if eq .Values.mode "distributed" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: None
+  ports:
+    - name: service
+      port: 9000
+      targetPort: {{ .Values.servicePort }}
+      protocol: TCP
+  selector:
+    app: {{ template "fullname" . }}
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  serviceName: {{ template "fullname" . }}
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: {{ template "fullname" . }}-user
+        - name: minio-configmap
+          configMap:
+            name: {{ template "fullname" . }}-cm
+        - name: minio-server-config
+          configMap:
+            name: {{ template "fullname" . }}-config-cm
+      containers:
+        - name: minio
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - /bin/sh
+            - /go/bin/start.sh
+          volumeMounts:
+            - name: export
+              mountPath: {{ .Values.mountPath }}
+            - name: minio-server-config
+              mountPath: {{ default "/root/.minio/" .Values.configPath | quote }}
+            - name: minio-configmap
+              mountPath: /go/bin/start.sh
+              subPath: start.sh
+          ports:
+            - name: service
+              containerPort: 9000
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}-user
+                  key: secretkey
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: export
+        annotations:
+          {{- if .Values.persistence.storageClass }}
+          volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+          {{- else }}
+          volume.alpha.kubernetes.io/storage-class: default
+          {{- end }}
+      spec:
+        accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/examples/minio/minio/templates/minio_svc.yaml
+++ b/examples/minio/minio/templates/minio_svc.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-svc
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.serviceType }}
+  {{- if eq .Values.serviceType "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.minioLoadBalancerIP }}
+  {{- end }}
+  selector:
+    app: {{ template "fullname" . }}
+  ports:
+    - name: service
+      port: 9000
+      targetPort: {{ .Values.servicePort }}
+      protocol: TCP

--- a/examples/minio/minio/templates/minioconfig_configmap.yaml
+++ b/examples/minio/minio/templates/minioconfig_configmap.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config-cm
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.json: |-
+    {
+      "version": "13",
+      "credential": {
+        "accessKey": {{ .Values.accessKey | quote }},
+        "secretKey": {{ .Values.secretKey | quote }}
+      },
+      "region": "us-east-1",
+      "logger": {
+        "console": {
+          "enable": true,
+          "level": "fatal"
+        },
+        "file": {
+          "enable": false,
+          "fileName": "",
+          "level": ""
+        }
+      },
+      "notify": {
+        "amqp": {
+          "1": {
+            "enable": {{ .Values.minioConfig.aqmp.enable }},
+            "url": {{ .Values.minioConfig.aqmp.url | quote }},
+            "exchange": {{ .Values.minioConfig.aqmp.exchange | quote }},
+            "routingKey": {{ .Values.minioConfig.aqmp.routingKey | quote }},
+            "exchangeType": {{ .Values.minioConfig.aqmp.exchangeType | quote }},
+            "mandatory": {{ .Values.minioConfig.aqmp.mandatory }},
+            "immediate": {{ .Values.minioConfig.aqmp.immediate }},
+            "durable": {{ .Values.minioConfig.aqmp.durable }},
+            "internal": {{ .Values.minioConfig.aqmp.internal }},
+            "noWait": {{ .Values.minioConfig.aqmp.noWait }},
+            "autoDeleted": {{ .Values.minioConfig.aqmp.autoDeleted }}
+          }
+        },
+        "nats": {
+          "1": {
+            "enable": {{ .Values.minioConfig.nats.enable }},
+            "address": {{ .Values.minioConfig.nats.address | quote }},
+            "subject": {{ .Values.minioConfig.nats.subject | quote }},
+            "username": {{ .Values.minioConfig.nats.username | quote }},
+            "password": {{ .Values.minioConfig.nats.password | quote }},
+            "token": {{ .Values.minioConfig.nats.token | quote }},
+            "secure": {{ .Values.minioConfig.nats.secure }},
+            "pingInterval": {{ .Values.minioConfig.nats.pingInterval | int64 }},
+            "streaming": {
+              "enable": {{ .Values.minioConfig.nats.enableStreaming }},
+              "clusterID": {{ .Values.minioConfig.nats.clusterID | quote }},
+              "clientID": {{ .Values.minioConfig.nats.clientID | quote }},
+              "async": {{ .Values.minioConfig.nats.async }},
+              "maxPubAcksInflight": {{ .Values.minioConfig.nats.maxPubAcksInflight | int }}
+            }
+          }
+        },
+        "elasticsearch": {
+          "1": {
+            "enable": {{ .Values.minioConfig.elasticsearch.enable }},
+            "url": {{ .Values.minioConfig.elasticsearch.url | quote }},
+            "index": {{ .Values.minioConfig.elasticsearch.index | quote }}
+          }
+        },
+        "redis": {
+          "1": {
+            "enable": {{ .Values.minioConfig.redis.enable }},
+            "address": {{ .Values.minioConfig.redis.address | quote }},
+            "password": {{ .Values.minioConfig.redis.password | quote }},
+            "key": {{ .Values.minioConfig.redis.key | quote }}
+          }
+        },
+        "postgresql": {
+          "1": {
+            "enable": {{ .Values.minioConfig.postgresql.enable }},
+            "connectionString": {{ .Values.minioConfig.postgresql.connectionString | quote }},
+            "table": {{ .Values.minioConfig.postgresql.table | quote }},
+            "host": {{ .Values.minioConfig.postgresql.host | quote }},
+            "port": {{ .Values.minioConfig.postgresql.port | quote }},
+            "user": {{ .Values.minioConfig.postgresql.user | quote }},
+            "password": {{ .Values.minioConfig.postgresql.password | quote }},
+            "database": {{ .Values.minioConfig.postgresql.database | quote }}
+          }
+        },
+        "kafka": {
+          "1": {
+            "enable": {{ .Values.minioConfig.kafka.enable }},
+            "brokers": {{ .Values.minioConfig.kafka.brokers }},
+            "topic": {{ .Values.minioConfig.kafka.topic | quote }}
+          }
+        },
+        "webhook": {
+          "1": {
+            "enable": {{ .Values.minioConfig.webhook.enable }},
+            "endpoint": {{ .Values.minioConfig.webhook.endpoint | quote }}
+          }
+        }
+      }
+    }

--- a/examples/minio/minio/values.yaml
+++ b/examples/minio/minio/values.yaml
@@ -1,0 +1,107 @@
+## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
+## minio server mode, i.e. standalone or distributed.
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+image: "minio/minio"
+imageTag: "RELEASE.2017-02-16T01-47-30Z"
+imagePullPolicy: "Always"
+mode: "standalone"
+
+## Set default accesskey, secretkey, Minio config file path, volume mount path and
+## number of nodes (only used for Minio distributed mode)
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
+accessKey: "foobar"
+secretKey: "foobarfoo"
+configPath: ""
+mountPath: "/export"
+replicas: 4
+
+## loadBalancerIP for the Minio Service (optional, cloud specific)
+## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+##
+# minioLoadBalancerIP:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: <storageClass>
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+## Expose the Minio service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+serviceType: LoadBalancer
+servicePort: 9000
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 250m
+
+## Below settings can be used to setup event notifications as explained here.
+## https://docs.minio.io/docs/minio-bucket-notification-guide
+##
+minioConfig:
+  aqmp:
+    enable: false
+    url: ""
+    exchange: ""
+    routingKey: ""
+    exchangeType: ""
+    mandatory: false
+    immediate: false
+    durable: false
+    internal: false
+    noWait: false
+    autoDeleted: false
+  nats:
+    enable: false
+    address: ""
+    subject: ""
+    username: ""
+    password: ""
+    token: ""
+    secure: false
+    pingInterval: 0
+    enableStreaming: false
+    clusterID: ""
+    clientID: ""
+    async: false
+    maxPubAcksInflight: 0
+  elasticsearch:
+    enable: false
+    url: ""
+    index: ""
+  redis:
+    enable: false
+    address: ""
+    password: ""
+    key: ""
+  postgresql:
+    enable: false
+    connectionString: ""
+    table: ""
+    host: ""
+    port: ""
+    user: ""
+    password: ""
+    database: ""
+  kafka:
+    enable: true
+    brokers: "[\"kafka.kubeless:9092\"]"
+    topic: "s3"
+  webhook:
+    enable: false
+    endpoint: ""

--- a/examples/minio/requirements.txt
+++ b/examples/minio/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes
+minio


### PR DESCRIPTION
This also contains a minio chart, which we can remove later once it is in the charts stable repo.

we will just be able to install it with:

```
helm install stable/minio
```